### PR TITLE
Highlight

### DIFF
--- a/qcweb/__init__.py
+++ b/qcweb/__init__.py
@@ -113,7 +113,7 @@ def query():
         print(form.errors)
         if is_valid:
             print('It validated')
-            flash(f'Query succussful {form.qcreport.data}!', 'success')
+            flash(f'Query succussful {form.qcreport.data}!', category='success')
             # grab the data from the query on the form
             qcreport = form.qcreport.data
             platform = form.platform.data
@@ -146,7 +146,7 @@ def query():
             else:
                 return redirect(url_for("plot"))
         assert not is_valid
-        flash(f'Form not valid {form.qcreport.data}!', 'warning')
+        flash(f'Form not valid {form.qcreport.data}!', category='warning')
         print('back to query.html')
     return render_template('query.html', title='Query', form=form,
             error=form.errors)

--- a/qcweb/static/style.css
+++ b/qcweb/static/style.css
@@ -84,12 +84,9 @@ a.article-title:hover {
   font-size: 2.5rem;
 }
 
-.alert.success {
-  background-color: green;
-}
-
 .alert.error {
-  background-color: red;
+  color: red;
+  background-color: #f0d6d6 !important;
 }
 
 /* Style buttons */

--- a/qcweb/templates/layout.html
+++ b/qcweb/templates/layout.html
@@ -1,73 +1,73 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <!-- Required meta tags -->
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <!-- Required meta tags -->
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-    <!-- Bootstrap CSS -->
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+  <!-- Bootstrap CSS -->
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+  <!-- JW external style CSS -->
+  <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='style.css') }}">
 
-    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='style.css') }}">
-
-    {% if title %}
-        <title>QC Report - {{ title }}</title>
-    {% else %}
-        <title>QC Report</title>
-    {% endif %}
+  {% if title %}
+    <title>QC Report - {{ title }}</title>
+  {% else %}
+    <title>QC Report</title>
+  {% endif %}
 </head>
 <body>
-    <header class="site-header">
-      <nav class="navbar navbar-expand-md navbar-dark bg-steel fixed-top">
-        <div class="container">
-          <!-- navbar-brand can be replaced with image -->
-          <a class="navbar-brand mr-4" href="/">QC Report</a>
-          <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarToggle" aria-controls="navbarToggle" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-          </button>
-          <div class="collapse navbar-collapse" id="navbarToggle">
-            <div class="navbar-nav mr-auto">
-              <a class="nav-item nav-link" href="{{ url_for('home') }}">Home</a>
-              <a class="nav-item nav-link" href="{{ url_for('query') }}">Query</a>
-              <a class="nav-item nav-link" href="{{ url_for('table') }}">Table</a>
-              <a class="nav-item nav-link" href="{{ url_for('plot') }}">Plot</a>
-            </div>
-            <!-- Navbar Right Side -->
-            <!--div class="navbar-nav"-->
-                <!--a class="nav-item nav-link" href="search">Search</a-->
-            <!--/div-->
+  <header class="site-header">
+    <nav class="navbar navbar-expand-md navbar-dark bg-steel fixed-top">
+      <div class="container">
+        <!-- navbar-brand can be replaced with image -->
+        <a class="navbar-brand mr-4" href="/">QC Report</a>
+        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarToggle" aria-controls="navbarToggle" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarToggle">
+          <div class="navbar-nav mr-auto">
+            <a class="nav-item nav-link" href="{{ url_for('home') }}">Home</a>
+            <a class="nav-item nav-link" href="{{ url_for('query') }}">Query</a>
+            <a class="nav-item nav-link" href="{{ url_for('table') }}">Table</a>
+            <a class="nav-item nav-link" href="{{ url_for('plot') }}">Plot</a>
           </div>
-        </div>
-      </nav>
-    </header>
-    <main role="main" class="container">
-      <div class="row">
-        <div class="col-md-8">
-          {% with messages = get_flashed_messages(with_categories=true) %}
-            <!-- Categories: success (green), info (blue), warning (yellow), danger (red) -->
-            {% if messages %}
-              {% for category, message in messages %}
-                <div class="alert alert-{{ category }}" role="alert">
-                  {{ message }}
-                </div>
-              {% endfor %}
-            {% endif %}
-          {% endwith %}
-          <!-- A child template may override this block content -->
-          {% block content %}{% endblock content %}
-          <!-- End of endblock content -->
-        </div>
-        <div class="col-md-4">
-          <!-- <div class="content-section"> -->
-          <!-- A child template may override this block sidebar-->
-          {% block sidebar %}{% endblock sidebar %}
-          <!-- End of endblock sidebar -->
+          <!-- Navbar Right Side -->
+          <!--div class="navbar-nav"-->
+            <!--a class="nav-item nav-link" href="search">Search</a-->
+          <!--/div-->
         </div>
       </div>
-    </main>
+    </nav>
+  </header>
+  <main role="main" class="container">
+    <div class="row">
+      <div class="col-md-8">
+        {% with messages = get_flashed_messages(with_categories=true) %}
+          <!-- Categories: success (green), info (blue), warning (yellow), danger (red) -->
+          {% if messages %}
+            {% for category, message in messages %}
+              <div class="alert alert-{{ category }}" role="alert">
+                {{ message }}
+              </div>
+            {% endfor %}
+          {% endif %}
+        {% endwith %}
+        <!-- A child template may override this block content -->
+        {% block content %}{% endblock content %}
+        <!-- End of endblock content -->
+      </div>
+      <div class="col-md-4">
+        <!-- <div class="content-section"> -->
+        <!-- A child template may override this block sidebar-->
+        {% block sidebar %}{% endblock sidebar %}
+        <!-- End of endblock sidebar -->
+      </div>
+    </div>
+  </main>
 
-{# AKA Cross-site request forgery #}
-<form method='POST'>
+  {# AKA Cross-site request forgery #}
+  <form method='POST'>
     {# The hidden_tag is CSRF security feature. #}
     <!-- Optional JavaScript -->
     <!-- jQuery first, then Popper.js, then Bootstrap JS -->

--- a/qcweb/templates/layout.html
+++ b/qcweb/templates/layout.html
@@ -44,9 +44,10 @@
       <div class="row">
         <div class="col-md-8">
           {% with messages = get_flashed_messages(with_categories=true) %}
+            <!-- Categories: success (green), info (blue), warning (yellow), danger (red) -->
             {% if messages %}
               {% for category, message in messages %}
-                <div class="alert alert-{{ category }}">
+                <div class= "alert alert-{{ category }}" role="alert">
                   {{ message }}
                 </div>
               {% endfor %}

--- a/qcweb/templates/layout.html
+++ b/qcweb/templates/layout.html
@@ -47,7 +47,7 @@
             <!-- Categories: success (green), info (blue), warning (yellow), danger (red) -->
             {% if messages %}
               {% for category, message in messages %}
-                <div class= "alert alert-{{ category }}" role="alert">
+                <div class="alert alert-{{ category }}" role="alert">
                   {{ message }}
                 </div>
               {% endfor %}

--- a/qcweb/templates/query.html
+++ b/qcweb/templates/query.html
@@ -4,31 +4,31 @@
   <body>
     <h1>Query Form</h1>
     {% for message in form.qcreport.errors %}
-      <div class="alert alert-danger">{{ message }}</div>
+      <div class="alert alert-info" role="alert">{{ message }}</div>
     {% endfor %}
     {% for message in form.platform.errors %}
-      <div class="alert alert-danger">{{ message }}</div>
+      <div class="alert alert-warning" role="alert">{{ message }}</div>
     {% endfor %}
     {% for message in form.group.errors %}
-      <div class="alert alert-danger">{{ message }}</div>
+      <div class="alert alert-warning" role="alert">{{ message }}</div>
     {% endfor %}
     {% for message in form.appl.errors %}
-      <div class="alert alert-danger">{{ message }}</div>
+      <div class="alert alert-warning" role="alert">{{ message }}</div>
     {% endfor %}
     {% for message in form.date_start.errors %}
-      <div class="alert alert-danger">{{ message }}</div>
+      <div class="alert alert-primary" role="alert">{{ message }}</div>
     {% endfor %}
     {% for message in form.time_start.errors %}
-      <div class="alert alert-danger">{{ message }}</div>
+      <div class="alert alert-danger" role="alert">{{ message }}</div>
     {% endfor %}
     {% for message in form.date_end.errors %}
-      <div class="alert alert-danger">{{ message }}</div>
+      <div class="alert alert-primary" role="alert">{{ message }}</div>
     {% endfor %}
     {% for message in form.time_end.errors %}
-      <div class="alert alert-danger">{{ message }}</div>
+      <div class="alert alert-danger" role="alert">{{ message }}</div>
     {% endfor %}
     {% for message in form.agg.errors %}
-      <div class="alert alert-danger">{{ message }}</div>
+      <div class="alert alert-warning" role="alert">{{ message }}</div>
     {% endfor %}
       <div class="content-section">
           <form method="POST" action="" target="_blank">

--- a/qcweb/templates/query.html
+++ b/qcweb/templates/query.html
@@ -4,7 +4,9 @@
   <body>
     <h1>Query Form</h1>
     {% for message in form.qcreport.errors %}
-      <div class="alert">{{ message }}</div>
+      <div class="alert" style="color: red; background-color: #f0d6d6; ">
+      {{ message }}
+      </div>
     {% endfor %}
     {% for message in form.platform.errors %}
       <div class="alert">{{ message }}</div>
@@ -16,16 +18,24 @@
       <div class="alert">{{ message }}</div>
     {% endfor %}
     {% for message in form.date_start.errors %}
-      <div class="alert">{{ message }}</div>
+      <div class="alert" style="color: red; background-color: #f0d6d6; ">
+      {{ message }}
+      </div>
     {% endfor %}
     {% for message in form.time_start.errors %}
-      <div class="alert">{{ message }}</div>
+      <div class="alert" style="color: red; background-color: #f0d6d6; ">
+      {{ message }}
+      </div>
     {% endfor %}
     {% for message in form.date_end.errors %}
-      <div class="alert">{{ message }}</div>
+      <div class="alert" style="color: red; background-color: #f0d6d6; ">
+      {{ message }}
+      </div>
     {% endfor %}
     {% for message in form.time_end.errors %}
-      <div class="alert">{{ message }}</div>
+      <div class="alert" style="color: red; background-color: #f0d6d6; ">
+      {{ message }}
+      </div>
     {% endfor %}
     {% for message in form.agg.errors %}
       <div class="alert">{{ message }}</div>

--- a/qcweb/templates/query.html
+++ b/qcweb/templates/query.html
@@ -16,13 +16,13 @@
       <div class="alert alert-warning" role="alert">{{ message }}</div>
     {% endfor %}
     {% for message in form.date_start.errors %}
-      <div class="alert alert-primary" role="alert">{{ message }}</div>
+      <div class="alert alert-danger" role="alert">{{ message }}</div>
     {% endfor %}
     {% for message in form.time_start.errors %}
       <div class="alert alert-danger" role="alert">{{ message }}</div>
     {% endfor %}
     {% for message in form.date_end.errors %}
-      <div class="alert alert-primary" role="alert">{{ message }}</div>
+      <div class="alert alert-danger" role="alert">{{ message }}</div>
     {% endfor %}
     {% for message in form.time_end.errors %}
       <div class="alert alert-danger" role="alert">{{ message }}</div>

--- a/qcweb/templates/query.html
+++ b/qcweb/templates/query.html
@@ -4,41 +4,31 @@
   <body>
     <h1>Query Form</h1>
     {% for message in form.qcreport.errors %}
-      <div class="alert" style="color: red; background-color: #f0d6d6; ">
-      {{ message }}
-      </div>
+      <div class="alert alert-danger">{{ message }}</div>
     {% endfor %}
     {% for message in form.platform.errors %}
-      <div class="alert">{{ message }}</div>
+      <div class="alert alert-danger">{{ message }}</div>
     {% endfor %}
     {% for message in form.group.errors %}
-      <div class="alert">{{ message }}</div>
+      <div class="alert alert-danger">{{ message }}</div>
     {% endfor %}
     {% for message in form.appl.errors %}
-      <div class="alert">{{ message }}</div>
+      <div class="alert alert-danger">{{ message }}</div>
     {% endfor %}
     {% for message in form.date_start.errors %}
-      <div class="alert" style="color: red; background-color: #f0d6d6; ">
-      {{ message }}
-      </div>
+      <div class="alert alert-danger">{{ message }}</div>
     {% endfor %}
     {% for message in form.time_start.errors %}
-      <div class="alert" style="color: red; background-color: #f0d6d6; ">
-      {{ message }}
-      </div>
+      <div class="alert alert-danger">{{ message }}</div>
     {% endfor %}
     {% for message in form.date_end.errors %}
-      <div class="alert" style="color: red; background-color: #f0d6d6; ">
-      {{ message }}
-      </div>
+      <div class="alert alert-danger">{{ message }}</div>
     {% endfor %}
     {% for message in form.time_end.errors %}
-      <div class="alert" style="color: red; background-color: #f0d6d6; ">
-      {{ message }}
-      </div>
+      <div class="alert alert-danger">{{ message }}</div>
     {% endfor %}
     {% for message in form.agg.errors %}
-      <div class="alert">{{ message }}</div>
+      <div class="alert alert-danger">{{ message }}</div>
     {% endfor %}
       <div class="content-section">
           <form method="POST" action="" target="_blank">


### PR DESCRIPTION
This will fix #49.

For visualization, I am using the below bootstrap contextual classes to set the level of error messages for query form fields:

alert-info:
qcreport

alert-warning:
platform, group, appl & agg

alert-danger:
date_start, time_start, date_end & time_end

So if there are multiple errors, they will have appropriate styles for the corresponding error messages.